### PR TITLE
Prevent null error on remove

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,9 @@ L.Marker.prototype.onRemove = function(map) {
 		var visible = self._map.getBounds().contains(self.getLatLng());
 		if (!visible) return _onRemove.apply(self, args);
 		iconInstance._cssOut(self._icon, self._shadow, function() {
+			self._map = self._mapToAdd = map;
 			_onRemove.apply(self, args);
+			self._map = self._mapToAdd = null;
 		});
 	} else {
 		_onRemove.apply(self, args);


### PR DESCRIPTION
The Leaflet Map.removeLayer() method sets the Marker.map and Marker.mapToAdd to null before the cssOut callback is called, causing an error when the Icon is removed.